### PR TITLE
dependencies to clj-1.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ The `midi` namespace is a work in progress.
 
 ## Usage
 
+    (use 'clj-audio.core)
+
 ### Playback
 
 Playing a wave file.

--- a/project.clj
+++ b/project.clj
@@ -1,8 +1,3 @@
-
-(defproject clj-audio/clj-audio "0.2.0-SNAPSHOT"
+(defproject clj-audio/clj-audio "0.3.0-SNAPSHOT"
   :description "Idiomatic Clojure wrapper for the Java Sound API."
-  :dependencies [[org.clojure/clojure "1.1.0"]
-                 [org.clojure/clojure-contrib "1.1.0"]]
-  :dev-dependencies [[lein-clojars "0.5.0-SNAPSHOT"]
-                     [swank-clojure "1.2.1"]
-                     [clj-help "0.1.1"]])
+  :dependencies [[org.clojure/clojure "1.5.1"]])

--- a/src/clj_audio/core.clj
+++ b/src/clj_audio/core.clj
@@ -10,8 +10,7 @@
        :doc "Clojure support for audio."}
   clj-audio.core
   (:use clj-audio.sampled
-        clj-audio.utils
-        [clojure.contrib.def :only [defvar]])
+        clj-audio.utils)
   (:import [javax.sound.sampled
             AudioInputStream
             AudioSystem
@@ -21,7 +20,7 @@
 
 ;;;; Audio formats
 
-(def *default-format*
+(def ^:dynamic *default-format* 
   (make-format
    {:encoding :pcm-signed
     :sample-rate 44100
@@ -131,19 +130,22 @@
 
 (def default-buffer-size (* 64 1024))
 
-(defvar *line-buffer-size*
-  default-buffer-size
+(def ^:dynamic *line-buffer-size* 
   "Line buffer size in bytes, must correspond to an integral number of
-  frames.")
-
-(defvar *playback-buffer-size*
+  frames."
   default-buffer-size
-  "Playback buffer size in bytes.")
+)
 
-(defvar *playing*
-  (ref false)
+(def ^:dynamic *playback-buffer-size* 
+"Playback buffer size in bytes."
+  default-buffer-size
+  )
+
+(def ^:dynamic *playing* 
   "Variable telling if play* is currently writing to a line. If set to
-  false during playback, play* will exit.")
+  false during playback, play* will exit."
+  (ref false)
+)
 
 (defn play*
   "Write the given audio stream bytes to the given source data line
@@ -218,7 +220,7 @@
 
 ;;;; Skipping
 
-(def *skip-inaccuracy-size* 1200)
+(def ^:dynamic *skip-inaccuracy-size* 1200)
 
 (defn skip
   "Skip the given audio stream by the specified number of bytes."

--- a/src/clj_audio/midi.clj
+++ b/src/clj_audio/midi.clj
@@ -9,8 +9,7 @@
 (ns #^{:author "Nicolas Buduroi"
        :doc "Wrapper for Java Sound API's midi package."}
   clj-audio.midi
-  (:use clj-audio.utils
-        [clojure.contrib.def :only [defmacro- defvar-]])
+  (:use clj-audio.utils)
   (:import java.io.File
            [javax.sound.midi
             MidiUnavailableException
@@ -24,7 +23,7 @@
 
 ;;;; MidiSystem
 
-(defmacro- return-nil-if-unavailable [& body]
+(defmacro return-nil-if-unavailable [& body]
   `(try ~@body
     (catch ~'MidiUnavailableException _# nil)))
 
@@ -159,7 +158,7 @@
 
 ;;;; Sequence
 
-(defvar- division-types (wrap-enum Sequence))
+(def division-types ^:private (wrap-enum Sequence))
 
 (defn empty-sequence
   "Creates an empty Sequence where division-type can be one

--- a/src/clj_audio/sampled.clj
+++ b/src/clj_audio/sampled.clj
@@ -9,8 +9,7 @@
 (ns #^{:author "Nicolas Buduroi"
        :doc "Wrapper for Java Sound API's sampled package."}
   clj-audio.sampled
-  (:use clj-audio.utils
-        [clojure.contrib.def :only [defvar defvar-]])
+  (:use clj-audio.utils)
   (:import [javax.sound.sampled
             AudioFormat
             AudioSystem
@@ -29,7 +28,7 @@
 
 ;;;; AudioFormat
 
-(defvar- encodings
+(def encodings ^:private
   (wrap-enum javax.sound.sampled.AudioFormat$Encoding))
 
 (defn make-format
@@ -85,10 +84,9 @@
 
 ;;;; Mixer
 
-(defvar *mixer*
-  nil
+(def ^:dynamic *mixer* 
   "Mixer to be be used by functions creating lines, if nil let the
-  system decides which mixer to use.")
+  system decides which mixer to use." nil)
 
 (defn mixer-info
   "Returns a map of common properties for the given Mixer object."
@@ -97,7 +95,7 @@
 
 ;;;; Line
 
-(defvar- line-types
+(def ^:private line-types 
   {:clip   Clip
    :input  TargetDataLine
    :output SourceDataLine
@@ -135,7 +133,7 @@
         result#)
       (finally (.close ~binding)))))
 
-(defvar- line-events
+(def line-events ^:private
   (wrap-enum javax.sound.sampled.LineEvent$Type
              :constants-as-keys))
 
@@ -235,9 +233,9 @@
 
 ;;;; AudioFileFormat
 
-(defvar file-types
-  (wrap-enum javax.sound.sampled.AudioFileFormat$Type)
-  "Map of audio file types, keyed by their corresponding keywords.")
+(def file-types
+  "Map of audio file types, keyed by their corresponding keywords."
+  (wrap-enum javax.sound.sampled.AudioFileFormat$Type))
 
 (defn ->file-format-info
   "Returns a map representing the given object's AudioFileFormat


### PR DESCRIPTION
- removed contrib things, one macro is not private anymore, otherwise equivalent state in more modern clojure
- removed all dependencies because of leiningen 2.0
- adding a use-row in README
